### PR TITLE
Fix special case of buggy mjpg servers and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,17 @@ Usage
 ```coffeescript
 # Initialize
 
-# Basic auth http://en.wikipedia.org/wiki/Basic_access_authentication
-auth = 'Basic ' + new Buffer('user:secret').toString('base64')
-
 # Same parameters as http.get http://nodejs.org/docs/v0.6.0/api/http.html#http.get
-paparazzo = new Paparazzo 
+paparazzo = new Paparazzo
   host: 'camera.dyndns.org'
   port: 1881
   path: '/mjpg/video.mjpg'
-  headers: { 'Authorization': auth }
+  auth: 'user:secret'
 
-paparazzo.on "update", (image) => 
+paparazzo.on "update", (image) =>
   console.log "Downloaded #{image.length} bytes"
 
-paparazzo.on 'error', (error) => 
+paparazzo.on 'error', (error) =>
   console.log "Error: #{error.message}"
 
 paparazzo.start()
@@ -68,7 +65,7 @@ var TIMEOUT = 2000;
 var refreshInterval = setInterval(function() {
   var random = Math.floor(Math.random() * Math.pow(2, 31));
   $('img#camera').attr('src', 'http://localhost:3000/camera?i=' + random);
-}, TIMEOUT);	
+}, TIMEOUT);
 ```
 
 ```html
@@ -87,18 +84,19 @@ Tested with
 -
 * Axis
 * Vivotek
+* D-Link
 
 Upcoming features
--  
+-
 * Websockets implementation to get more FPS
 
 TODO
--  
+-
 * More tests
 * Find more public cameras to test
 
-License  
--  
+License
+-
 
 <a rel="license" href="http://opensource.org/licenses/MIT">The MIT License (MIT)</a>
 

--- a/demo/server.coffee
+++ b/demo/server.coffee
@@ -36,8 +36,8 @@ paparazzo.start()
 http.createServer (req, res) ->
     data = ''
     path = url.parse(req.url).pathname
-        
-    if path == '/camera' and updatedImage?
+
+    if path == '/camera' and updatedImage
         data = updatedImage
         console.log "Will serve image of #{data.length} bytes"
 

--- a/src/paparazzo.coffee
+++ b/src/paparazzo.coffee
@@ -68,6 +68,8 @@ class Paparazzo extends EventEmitter
       boundary = '--myboundary'
       @emit 'error',
         message: "Couldn't find a boundary string. Falling back to --myboundary."
+    else if boundary.indexOf '--' isnt 0
+      boundary = '--' + boundary
     boundary
 
   ###

--- a/src/paparazzo.coffee
+++ b/src/paparazzo.coffee
@@ -3,7 +3,7 @@
 #
 #   paparazzo = new Paparazzo(options)
 #
-#   paparazzo.on "update", (image) => 
+#   paparazzo.on "update", (image) =>
 #     console.log "Downloaded #{image.length} bytes"
 #
 #   paparazzo.start()
@@ -61,7 +61,7 @@ class Paparazzo extends EventEmitter
     # M-JPEG content type looks like multipart/x-mixed-replace;boundary=<boundary-name>
     match = type.match(/multipart\/x-mixed-replace;\s*boundary=(.+)/)
     boundary = match[1] if match?.length > 1
-    if not boundary?
+    unless boundary
       boundary = '--myboundary'
       @emit 'error',
         message: "Couldn't find a boundary string. Falling back to --myboundary."
@@ -81,7 +81,7 @@ class Paparazzo extends EventEmitter
   #
   ###
   handleServerResponse: (chunk) =>
-    boundary_index = chunk.indexOf(@boundary)
+    boundary_index = chunk.indexOf @boundary
 
     # If a boundary is found, generate a new image from the data accumulated up to the boundary.
     # Otherwise keep eating. We will probably find a boundary in the next chunk.

--- a/src/paparazzo.coffee
+++ b/src/paparazzo.coffee
@@ -17,16 +17,13 @@ class Paparazzo extends EventEmitter
   @image = ''
   imageExpectedLength = -1
 
-  constructor: (options) ->
+  constructor: (@options) ->
 
-    if not options.host?
+    unless @options.host
       emitter.emit 'error',
         message: 'Host is not defined!'
-    options.port or= 80
-    options.path or= '/'
-    options.headers or= {}
-    @options = options
-    @memory = options.memory or 8388608 # 8MB
+    @memory = @options.memory or 8388608 # 8MB
+    delete @options.memory
 
   start: ->
 

--- a/src/paparazzo.coffee
+++ b/src/paparazzo.coffee
@@ -45,7 +45,7 @@ class Paparazzo extends EventEmitter
 
       response.setEncoding 'binary'
       response.on 'data', emitter.handleServerResponse
-      response.on 'end', () ->
+      response.on 'end', ->
         emitter.emit 'error',
           message: "Server closed connection!"
 

--- a/src/paparazzo.js
+++ b/src/paparazzo.js
@@ -78,6 +78,8 @@
         this.emit('error', {
           message: "Couldn't find a boundary string. Falling back to --myboundary."
         });
+      } else if (boundary.indexOf('--' !== 0)) {
+        boundary = '--' + boundary;
       }
       return boundary;
     };

--- a/src/paparazzo.js
+++ b/src/paparazzo.js
@@ -19,17 +19,15 @@
     imageExpectedLength = -1;
 
     function Paparazzo(options) {
+      this.options = options;
       this.handleServerResponse = __bind(this.handleServerResponse, this);
-      if (options.host == null) {
+      if (!this.options.host) {
         emitter.emit('error', {
           message: 'Host is not defined!'
         });
       }
-      options.port || (options.port = 80);
-      options.path || (options.path = '/');
-      options.headers || (options.headers = {});
-      this.options = options;
-      this.memory = options.memory || 8388608;
+      this.memory = this.options.memory || 8388608;
+      delete this.options.memory;
     }
 
     Paparazzo.prototype.start = function() {
@@ -73,7 +71,7 @@
       if ((match != null ? match.length : void 0) > 1) {
         boundary = match[1];
       }
-      if (boundary == null) {
+      if (!boundary) {
         boundary = '--myboundary';
         this.emit('error', {
           message: "Couldn't find a boundary string. Falling back to --myboundary."

--- a/test/paparazzoTest.coffee
+++ b/test/paparazzoTest.coffee
@@ -18,8 +18,4 @@ describe 'Paparazzo constructor', ->
         paparazzo = new Paparazzo
             host: '85.105.120.239'
         paparazzo.options.path.should.equal '/'
-    it 'should be initialized with a host parameter', ->
-        paparazzo = new Paparazzo
-            port: 1337
-        paparazzo.should.equal {}
 


### PR DESCRIPTION
Main changes are on src/paparazzo.coffee, the change handles buggy mjpeg servers that set the boundary header without the starting dashes. I ended up doing a bunch of other tiny fixes in documentation, syntax and style. Removed a test that always failed for me. But I guess I kinda fucked up the whitespace.

Por otro lado me da un chingo de gusto ver a alguien trabajando con Nodejs y especialmente con Coffeescript en la Ciudad de México, hice un poco de stalking y me di cuenta que hicimos un par de aplicaciones con fines similares, yo soy dueño de garitas-tijuana.com

Saludos!
