### PR TITLE
Fixes make's compile and run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-install: compile
+install:
 	npm install
 
 compile:
-	@find src  -name '*.coffee' | xargs coffee -c
-	@find demo -name '*.coffee' | xargs coffee -c
+	@find src  -name '*.coffee' | xargs node_modules/coffee-script/bin/coffee -c
+	@find demo -name '*.coffee' | xargs node_modules/coffee-script/bin/coffee -c
 
-run: install
+run: install compile
 	open demo/demo.html
 	node demo/bootstrap.js
 
 test:
 	./node_modules/.bin/mocha --compilers coffee:coffee-script -R spec
 
-.PHONY: test
+.PHONY: test run


### PR DESCRIPTION
- install should be run before compile
- compile should use local coffee binary
- run should be a phony target that runs install and compile
